### PR TITLE
Add prerequisites for Python 3.12 and uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@ This repository contains exploratory notebooks and planning documents for a mult
 - [PRD.md](PRD.md) describes the product requirements for building the agents.
 - [PLAN.md](PLAN.md) outlines the development tasks and architecture approach.
 
+## Prerequisites
+
+- Python 3.12
+- Install `uv`:
+  ```bash
+  pip install uv
+  ```
+
 ## Development Setup
 
-Install dependencies using `uv` and run the pre-configured quality checks via `make`:
+Install dependencies using `uv` and run the pre-configured quality checks via `make`. The commands `make install`, `make lint`, `make format` and `make test` depend on `uv`:
 
 ```bash
 make install


### PR DESCRIPTION
## Summary
- mention Python 3.12 in prerequisites
- show how to install `uv`
- clarify that `make install`, `make lint`, `make format` and `make test` depend on `uv`

## Testing
- `black --check .`
- `pytest`
- `uv pip install -e .[develop] --system` *(fails: No solution found)*
- `ruff .` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_684bf8f14ec8832f967fb1820d542f58