### PR TITLE
Add CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ make test
 ```
 
 The project follows a clean architecture layout under the `domain`, `application`, `interfaces`, and `infrastructure` packages.
+
+## CLI Usage
+
+Run the command-line interface with Python's `-m` option:
+
+```bash
+python -m multi_agent_system execute-command hello
+```

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -1,0 +1,45 @@
+"""Command-line interface for the multi-agent system."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def execute_command(command_name: str) -> None:
+    """Execute a named command.
+
+    Parameters
+    ----------
+    command_name:
+        Name of the command to execute.
+    """
+    print(f"Executing: {command_name}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create and return the top-level argument parser."""
+    parser = argparse.ArgumentParser(prog="multi_agent_system")
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    exec_parser = subparsers.add_parser(
+        "execute-command", help="Execute a registered command"
+    )
+    exec_parser.add_argument("name", help="Name of the command to run")
+    exec_parser.set_defaults(func=lambda args: execute_command(args.name))
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point used by the console script and ``python -m``."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/multi_agent_system/__init__.py
+++ b/multi_agent_system/__init__.py
@@ -1,0 +1,1 @@
+"""Package entry for the multi-agent system."""

--- a/multi_agent_system/__main__.py
+++ b/multi_agent_system/__main__.py
@@ -1,0 +1,4 @@
+from interfaces.cli import main
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ develop = [
     "pre-commit",
     "pytest",
 ]
+[project.scripts]
+multi-agent-system = "multi_agent_system.__main__:main"
+
 
 [tool.black]
 target-version = ["py312"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,7 @@
+from interfaces.cli import main
+
+
+def test_execute_command(capsys):
+    main(["execute-command", "test"])
+    captured = capsys.readouterr()
+    assert "Executing: test" in captured.out


### PR DESCRIPTION
## Summary
- implement initial CLI with argparse
- add module package `multi_agent_system` with `__main__`
- register console script
- document CLI usage in README
- test CLI command

## Testing
- `ruff check .`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684bfeabaa70832f84777662a69f0dcd