### PR TITLE
Implement Neo4J repository

### DIFF
--- a/infrastructure/neo4j_graph.py
+++ b/infrastructure/neo4j_graph.py
@@ -1,0 +1,52 @@
+"""Neo4J graph repository implementation."""
+
+from __future__ import annotations
+
+from domain.repositories import GraphRepository
+
+try:
+    from neo4j import GraphDatabase
+except Exception:  # pragma: no cover - fallback when neo4j is missing
+    GraphDatabase = None  # type: ignore
+
+
+class Neo4JGraphRepository(GraphRepository):
+    """Repository backed by a Neo4J database."""
+
+    def __init__(self, uri: str, user: str, password: str) -> None:
+        if GraphDatabase is None:  # pragma: no cover - environment without neo4j
+            raise ImportError("neo4j driver is not installed")
+        self._driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self) -> None:
+        """Close the underlying Neo4J driver."""
+        self._driver.close()
+
+    # ------------------------------------------------------------------
+    # GraphRepository API
+    # ------------------------------------------------------------------
+    def add_node(self, node: dict) -> None:  # pragma: no cover - placeholder
+        """Persist a node using a Cypher query."""
+        if GraphDatabase is None:
+            raise NotImplementedError("neo4j driver is required for add_node")
+
+        node_id = node.get("id")
+        if not node_id:
+            raise ValueError("node must have an 'id'")
+
+        query = "MERGE (n {id: $id}) SET n += $props"
+        with self._driver.session() as session:
+            session.run(query, id=node_id, props=node)
+
+    def get_node(self, node_id: str) -> dict:  # pragma: no cover - placeholder
+        """Retrieve a node by id using a Cypher query."""
+        if GraphDatabase is None:
+            raise NotImplementedError("neo4j driver is required for get_node")
+
+        query = "MATCH (n {id: $id}) RETURN properties(n) AS node"
+        with self._driver.session() as session:
+            result = session.run(query, id=node_id)
+            record = result.single()
+            if record is None:
+                raise KeyError(node_id)
+            return dict(record["node"])

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -1,0 +1,43 @@
+from infrastructure.neo4j_graph import Neo4JGraphRepository
+import pytest
+from unittest.mock import MagicMock
+
+
+def _setup_repo(monkeypatch):
+    mock_session = MagicMock()
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__.return_value = mock_session
+
+    mock_graph_db = MagicMock()
+    mock_graph_db.driver.return_value = mock_driver
+    monkeypatch.setattr(
+        "infrastructure.neo4j_graph.GraphDatabase", mock_graph_db, raising=False
+    )
+
+    repo = Neo4JGraphRepository("bolt://localhost:7687", "user", "pass")
+    return repo, mock_session
+
+
+def test_add_and_get_node(monkeypatch):
+    repo, session = _setup_repo(monkeypatch)
+    node = {"id": "1", "value": "test"}
+
+    repo.add_node(node)
+    session.run.assert_called_with(
+        "MERGE (n {id: $id}) SET n += $props", id="1", props=node
+    )
+
+    result = MagicMock()
+    result.single.return_value = {"node": node}
+    session.run.return_value = result
+
+    assert repo.get_node("1") == node
+    session.run.assert_called_with(
+        "MATCH (n {id: $id}) RETURN properties(n) AS node", id="1"
+    )
+
+
+def test_add_node_missing_id_raises_value_error(monkeypatch):
+    repo, _ = _setup_repo(monkeypatch)
+    with pytest.raises(ValueError):
+        repo.add_node({"value": "no id"})


### PR DESCRIPTION
## Summary
- add `Neo4JGraphRepository` for Neo4J persistence
- support adding and retrieving nodes
- add unit tests using monkeypatch and mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0403d320832f9933636be62bb0c7