### PR TITLE
Add Dockerfiles for agents and new run target

### DIFF
--- a/Dockerfile.arx
+++ b/Dockerfile.arx
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+ENV ROLE=arx
+CMD ["python", "-m", "multi_agent_system", "execute-command", "hello"]

--- a/Dockerfile.d
+++ b/Dockerfile.d
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+ENV ROLE=d
+CMD ["python", "-m", "multi_agent_system", "execute-command", "hello"]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,24 @@
 .PHONY: install lint format test precommit build
 
 install:
-uv pip install -e .[develop]
+	uv pip install -e .[develop]
 
 lint:
-ruff .
+	ruff .
 
 format:
-black .
+	black .
 
 precommit:
-pre-commit run --all-files
+	pre-commit run --all-files
 
 test:
-pytest
+	pytest
 
 build:
-echo "Build placeholder"
+	echo "Build placeholder"
+
+run:
+	@ROLE=$${ROLE:-arx}; \
+	docker build -f Dockerfile.$${ROLE} -t multi-agent-system-$${ROLE} . && \
+	docker run --rm multi-agent-system-$${ROLE}

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ Run the command-line interface with Python's `-m` option:
 ```bash
 python -m multi_agent_system execute-command hello
 ```
+
+## Running with Docker
+
+You can build and run an agent container using the `make run` target. Pass the
+desired agent role via the `ROLE` variable (`arx` for the architect agent or
+`d` for the developer agent). For example:
+
+```bash
+make run ROLE=arx  # build and start the architect container
+make run ROLE=d    # build and start the developer container
+```


### PR DESCRIPTION
## Summary
- add Dockerfile.arx and Dockerfile.d for architect and developer roles
- fix Makefile commands and add `run` target for building and running a role-specific image
- document `make run` usage in README

## Testing
- `make lint` *(fails: ruff missing)*
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c05d1f494832f9c6aad9cf445d897