### PR TITLE
Add CI workflow with lint, format check and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install uv
+          make install
+      - name: Lint
+        run: make lint
+      - name: Format check
+        run: make format --check
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install lint format test precommit build
 
 install:
-	uv pip install -e .[develop]
+	uv pip install --system -e .[develop]
 
 lint:
 	ruff .

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ make format
 make test
 ```
 
+## Continuous Integration
+
+All contributions are validated by a GitHub Actions workflow that executes `make lint`, `make format --check` and `make test` on every pull request.
+
 The project follows a clean architecture layout under the `domain`, `application`, `interfaces`, and `infrastructure` packages.
 
 ## CLI Usage


### PR DESCRIPTION
## Summary
- run `make lint`, `make format --check` and `make test` on pull requests
- document the CI workflow in the README

## Testing
- `make lint` *(fails: unrecognized subcommand due to missing dependencies)*
- `make format --check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684c3e12a848832fac345b7c67d069b5